### PR TITLE
Fix test `testUpdateBranchGrayRulesWithUpdateOnce`

### DIFF
--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/NamespaceBranchServiceTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/NamespaceBranchServiceTest.java
@@ -82,7 +82,15 @@ public class NamespaceBranchServiceTest extends AbstractIntegrationTest {
     Assert.assertEquals(ReleaseOperation.APPLY_GRAY_RULES, releaseHistory.getOperation());
     Assert.assertEquals(0, releaseHistory.getReleaseId());
     Assert.assertEquals(0, releaseHistory.getPreviousReleaseId());
-    Assert.assertTrue(releaseHistory.getOperationContext().contains(rule.getRules()));
+    Assert.assertTrue(containRule(releaseHistory.getOperationContext(),rule.getRules()));
+  }
+
+  public boolean containRule(String context, String rule){
+    boolean contains = true;
+    String[] rules = rule.substring(2,rule.length()-2).split(",");
+    for (int i = 0; i<rules.length; i++)
+      contains = contains && context.contains(rules[i]);
+    return contains;
   }
 
   @Test


### PR DESCRIPTION
## What's the purpose of this PR

Fix test `testUpdateBranchGrayRulesWithUpdateOnce`

## Which issue(s) this PR fixes:
Fixes the issue that causes flaky tests. The current test may lead to inconsistent ordering of stringified JSON objects and the test may fail sometimes. To fix the test and make it consistent, I select all the elements in the list and see whether the release history contains those elements. In this case, the ordering of the elements doesn't matter and won't cause failure.


